### PR TITLE
Fix Token Refresh Expiry Time Calculation Bug

### DIFF
--- a/app/src/debug/kotlin/previews/DevicePreviewProfiles.kt
+++ b/app/src/debug/kotlin/previews/DevicePreviewProfiles.kt
@@ -1,9 +1,10 @@
 package previews
 
+import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Preview
 
-@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480")
-@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480")
-@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Preview(name = "phone", device = "spec:shape=Normal,width=360,height=640,unit=dp,dpi=480", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "landscape", device = "spec:shape=Normal,width=640,height=360,unit=dp,dpi=480", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480", uiMode = Configuration.UI_MODE_NIGHT_YES)
 annotation class DevicePreviewProfiles

--- a/app/src/main/java/com/jonecx/qio/MainActivity.kt
+++ b/app/src/main/java/com/jonecx/qio/MainActivity.kt
@@ -30,6 +30,7 @@ import com.jonecx.qio.feature.appstate.AppState.AppStateLoading
 import com.jonecx.qio.feature.appstate.AppState.AppStateSuccess
 import com.jonecx.qio.feature.authentication.AuthorizationScreen
 import com.jonecx.qio.feature.authentication.ErrorScreen
+import com.jonecx.qio.feature.authentication.LoadingScreen
 import com.jonecx.qio.feature.authentication.LoginState
 import com.jonecx.qio.feature.authentication.LoginViewModel
 import com.jonecx.qio.settings.proto.ThemeConfig
@@ -98,6 +99,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         when (authenticationState) {
                             LoginState.LoginStateLoading -> loginViewModel.getCurrentAuthenticationState()
+                            LoginState.LoginStateRefreshing -> LoadingScreen()
                             LoginState.LoginStateError -> ErrorScreen()
                             LoginState.LoginStateSuccess -> QioApp(
                                 windowSizeClass = calculateWindowSizeClass(this),

--- a/app/src/main/java/com/jonecx/qio/feature/authentication/ErrorScreen.kt
+++ b/app/src/main/java/com/jonecx/qio/feature/authentication/ErrorScreen.kt
@@ -1,0 +1,35 @@
+package com.jonecx.qio.feature.authentication
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.jonecx.qio.ui.theme.QioBackground
+import com.jonecx.qio.ui.theme.QioTheme
+import previews.DevicePreviewProfiles
+
+@Composable
+fun ErrorScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.error),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(":( failure")
+    }
+}
+
+@DevicePreviewProfiles
+@Composable
+fun ErrorScreenPreview() {
+    QioTheme {
+        QioBackground {
+            ErrorScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/jonecx/qio/feature/authentication/LoadingScreen.kt
+++ b/app/src/main/java/com/jonecx/qio/feature/authentication/LoadingScreen.kt
@@ -1,0 +1,36 @@
+package com.jonecx.qio.feature.authentication
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jonecx.qio.ui.QioCircularProgress
+import com.jonecx.qio.ui.theme.QioBackground
+import com.jonecx.qio.ui.theme.QioTheme
+import previews.DevicePreviewProfiles
+
+@Composable
+fun LoadingScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        QioCircularProgress(size = 90.dp)
+    }
+}
+
+@DevicePreviewProfiles
+@Composable
+fun LoadingScreenPreview() {
+    QioTheme {
+        QioBackground {
+            LoadingScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/jonecx/qio/feature/authentication/LoginScreen.kt
+++ b/app/src/main/java/com/jonecx/qio/feature/authentication/LoginScreen.kt
@@ -1,19 +1,10 @@
 package com.jonecx.qio.feature.authentication
 
-import android.content.res.Configuration
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import timber.log.Timber
 
@@ -46,26 +37,4 @@ fun AuthorizationScreen(authorizeAccess: (String) -> Unit) {
     }, update = {
         it.loadUrl(OauthUtils.authorizeRequestUrl)
     })
-}
-
-@Composable
-fun ErrorScreen() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Red),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(":( failure")
-    }
-}
-
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, name = "Light theme")
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Dark theme")
-annotation class ThemePreviews
-
-@Preview
-@Composable
-fun ErrorScreenPreview() {
-    ErrorScreen()
 }

--- a/app/src/main/java/com/jonecx/qio/model/OauthTokenInfo.kt
+++ b/app/src/main/java/com/jonecx/qio/model/OauthTokenInfo.kt
@@ -7,7 +7,7 @@ import java.time.Instant
 @Serializable
 data class OauthTokenInfo(
     @SerialName("access_token") val accessToken: String = "",
-    @SerialName("expires_in") val expiresIn: Int = 0,
+    @SerialName("expires_in") var expiresIn: Long = 0,
     @SerialName("token_type") val tokenType: String = "",
     val scope: String = "",
     @SerialName("id_token") val idToken: Boolean = false,
@@ -20,6 +20,5 @@ fun OauthTokenInfo.isValid(): Boolean {
 
 fun OauthTokenInfo.isTokenExpired(): Boolean {
     val currentTimeInSeconds = Instant.now().epochSecond
-    val tokenExpiryTime = currentTimeInSeconds + expiresIn.toLong()
-    return currentTimeInSeconds > tokenExpiryTime
+    return currentTimeInSeconds > expiresIn
 }

--- a/app/src/main/java/com/jonecx/qio/network/ApiService.kt
+++ b/app/src/main/java/com/jonecx/qio/network/ApiService.kt
@@ -19,14 +19,15 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+import java.time.Instant
 import javax.inject.Inject
 
 class ApiService @Inject constructor(private val encryptedStorage: SharedPreferences, private val httpClient: HttpClient) : IApiService {
 
     override fun authorize(authorizationCode: String): Flow<ApiResult<OauthTokenInfo>> = flow {
-        emit(Loading())
         try {
             val url = BuildConfig.AUTHORIZATION_CODE_GRANT_URL
             val response = httpClient.post(url) {
@@ -42,7 +43,6 @@ class ApiService @Inject constructor(private val encryptedStorage: SharedPrefere
     }
 
     override fun refreshToken(oauthTokenInfo: OauthTokenInfo): Flow<ApiResult<OauthTokenInfo>> = flow {
-        emit(Loading())
         try {
             val url = BuildConfig.AUTHORIZATION_CODE_GRANT_URL
             val response = httpClient.post(url) {
@@ -70,17 +70,20 @@ class ApiService @Inject constructor(private val encryptedStorage: SharedPrefere
     private suspend fun handleAuthenticationResult(httpResponse: HttpResponse): ApiResult<OauthTokenInfo> {
         return if (httpResponse.status.value == 200) {
             val oauthInfoJson = httpResponse.bodyAsText()
-            saveAuthenticationState(oauthInfoJson)
-            val refreshedOauthTokenInfo = Json.decodeFromString<OauthTokenInfo>(oauthInfoJson)
+            val refreshedOauthTokenInfo = Json.decodeFromString<OauthTokenInfo>(oauthInfoJson).also {
+                // update the token expiry time
+                it.expiresIn += Instant.now().epochSecond
+            }
+            saveAuthenticationState(refreshedOauthTokenInfo)
             Success(refreshedOauthTokenInfo)
         } else {
             Error("Authorization failed!")
         }
     }
 
-    private fun saveAuthenticationState(oauthInfoJson: String) {
+    private fun saveAuthenticationState(oauthTokenInfo: OauthTokenInfo) {
         with(encryptedStorage.edit()) {
-            putString("token", oauthInfoJson)
+            putString("token", Json.encodeToString(oauthTokenInfo))
             apply()
         }
     }


### PR DESCRIPTION
This PR addresses an issue where the expiry time for token refresh was being calculated incorrectly, leading to unexpected behavior when attempting to refresh tokens. The bug was causing the application to inaccurately determine the validity of refresh tokens